### PR TITLE
Associate yang.settings to yang-lsp-settings-schema.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
                 "category": "Yang Diagram"
             }
         ],
+        "jsonValidation": [
+            {
+                "fileMatch": "yang.settings",
+                "url": "https://raw.githubusercontent.com/TypeFox/yang-lsp/master/schema/yang-lsp-settings-schema.json"
+            }
+        ],
         "menus": {
             "editor/context": [
                 {


### PR DESCRIPTION
This addresses TypeFox/yang-vscode#82

The URL is currently towards the latest schema file, and will be
updated to the schema distributed version when it is available.

Signed-off-by: Siddharth Sharma <siddharth.sharma@ericsson.com>