### PR TITLE
Associate yang.settings as JSON with Comments

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Yang Extension (embedded-ls)",
+            "name": "YANG LSP Extension (embedded-ls)",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
@@ -17,7 +17,7 @@
             "sourceMaps": true
         },
         {
-            "name": "Yang Extension (socket-ls)",
+            "name": "YANG LSP Extension (socket-ls)",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -64,7 +64,7 @@ export class YangLanguageExtension extends SprottyLspVscodeExtension {
                 fileEvents: workspace.createFileSystemWatcher('**/*.yang')
             }
         }
-        const clientId = {id: 'yangLanguageServer', name: 'Yang Language Server'};
+        const clientId = {id: 'yangLanguageServer', name: 'YANG Language Server'};
         // Create the language client and start the client.
         const languageClient = DEBUG
             ? getSocketLanguageClient(clientId, clientOptions, SERVER_PORT)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "yang-vscode",
     "displayName": "Yangster",
-    "description": "Yang editor support and diagrams for VS Code",
+    "description": "YANG editor support and diagrams for VS Code",
     "version": "2.3.2",
     "publisher": "typefox",
     "license": "Apache-2.0",
@@ -35,6 +35,7 @@
             {
                 "id": "yang",
                 "aliases": [
+                    "YANG",
                     "Yang",
                     "yang"
                 ],
@@ -42,6 +43,15 @@
                     ".yang"
                 ],
                 "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "jsonc",
+                "aliases": [
+                    "yang-lsp settings"
+                ],
+                "filenames": [
+                    "yang.settings"
+                ]
             }
         ],
         "grammars": [
@@ -53,7 +63,7 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "Yang client configuration",
+            "title": "YANG client configuration",
             "properties": {
                 "yangLanguageServer.maxNumberOfProblems": {
                     "type": "number",
@@ -66,22 +76,22 @@
             {
                 "command": "yang.diagram.open",
                 "title": "Open in Diagram",
-                "category": "Yang Diagram"
+                "category": "YANG Diagram"
             },
             {
                 "command": "yang.diagram.fit",
                 "title": "Fit to Screen",
-                "category": "Yang Diagram"
+                "category": "YANG Diagram"
             },
             {
                 "command": "yang.diagram.center",
                 "title": "Center Selection",
-                "category": "Yang Diagram"
+                "category": "YANG Diagram"
             },
             {
                 "command": "yang.diagram.export",
                 "title": "Export Diagram to SVG",
-                "category": "Yang Diagram"
+                "category": "YANG Diagram"
             }
         ],
         "jsonValidation": [

--- a/syntaxes/yang.tmLanguage.json
+++ b/syntaxes/yang.tmLanguage.json
@@ -1,6 +1,6 @@
 {
 	"scopeName": "source.yang",
-	"name": "Yang",
+	"name": "YANG",
 	"fileTypes": ["yang"],
 	"patterns": [
 		{


### PR DESCRIPTION
Also rename Yang to YANG as the canonical representation in IETF RFCs.

This addresses TypeFox/yang-vscode#81

Signed-off-by: Siddharth Sharma <siddharth.sharma@ericsson.com>