### PR TITLE
Clear markdownlint warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+
+[*.yang]
+indent_style = space
+indent_size = 4
+
+[{*.ts,*.js}]
+indent_style = space
+indent_size = 4
+
+[*.json]
+indent_style = space
+indent_size = 4
+
+[*.tmLanguage.json]
+indent_style = tab
+indent_size = 4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  mdlint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DavidAnson/markdownlint-cli2-action@v15
+      with:
+        globs: |
+          **/*.md
+          !server/**/*.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "markdownlint.ignore": ".gitignore"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,59 @@
 # Change Log
+
 ## v2.3.2
- * Update [yang-lsp](https://github.com/TypeFox/yang-lsp) to version [0.7.4](https://github.com/TypeFox/yang-lsp/releases/tag/v0.7.4)
- * Fixed - Formatting not honoring VS Code settings [#70](https://github.com/TypeFox/yang-vscode/issues/70)
+
+* Update [yang-lsp][yang-lsp] to version [0.7.4](https://github.com/TypeFox/yang-lsp/releases/tag/v0.7.4)
+* Fixed - Formatting not honoring VS Code settings [#70](https://github.com/TypeFox/yang-vscode/issues/70)
 
 ## v2.3.1
- * Update [yang-lsp](https://github.com/TypeFox/yang-lsp) to version [0.7.3](https://github.com/TypeFox/yang-lsp/releases/tag/v0.7.3)
+
+* Update [yang-lsp][yang-lsp] to version [0.7.3](https://github.com/TypeFox/yang-lsp/releases/tag/v0.7.3)
 
 ## v2.3.0
- * Update [yang-lsp](https://github.com/TypeFox/yang-lsp) to version [0.7.2](https://github.com/TypeFox/yang-lsp/releases/tag/v0.7.2)
+
+* Update [yang-lsp][yang-lsp] to version [0.7.2](https://github.com/TypeFox/yang-lsp/releases/tag/v0.7.2)
 
 ## v2.2.0
- * Update [yang-lsp](https://github.com/TypeFox/yang-lsp) to version [0.7.0](https://github.com/TypeFox/yang-lsp/releases/tag/v0.7.0)
- * Update [sprotty-vscode](https://github.com/eclipse/sprotty-vscode) version 0.3.1
- * Update [yang-sprotty](https://github.com/TypeFox/yang-sprotty) to version 0.3.0
- * Update vscode-languageclient to version 7.0
+
+* Update [yang-lsp][yang-lsp] to version [0.7.0](https://github.com/TypeFox/yang-lsp/releases/tag/v0.7.0)
+* Update [sprotty-vscode][sprotty-vscode] version 0.3.1
+* Update [yang-sprotty][yang-sprotty] to version 0.3.0
+* Update vscode-languageclient to version 7.0
 
 ## v2.1.0
 
- * Update [yang-lsp](https://github.com/TypeFox/yang-lsp) to version 0.5.0
+* Update [yang-lsp][yang-lsp] to version 0.5.0
+
 ## v2.0.6
 
- * Update [yang-lsp](https://github.com/TypeFox/yang-lsp) to version 0.4.0
+* Update [yang-lsp][yang-lsp] to version 0.4.0
+
 ## v2.0.5
 
- * Update [yang-lsp](https://github.com/TypeFox/yang-lsp) to version 0.3.1
+* Update [yang-lsp][yang-lsp] to version 0.3.1
+
 ## v2.0.4
 
- * Update [yang-lsp](https://github.com/TypeFox/yang-lsp) to version 0.3.0
+* Update [yang-lsp][yang-lsp] to version 0.3.0
 
 ## v2.0.3
 
- * Fixed [#14](https://github.com/TypeFox/yang-vscode/issues/14)
+* Fixed [#14](https://github.com/TypeFox/yang-vscode/issues/14)
 
 ## v2.0.2
 
- * Update [yang-lsp](https://github.com/TypeFox/yang-lsp) to version 0.2.0
+* Update [yang-lsp][yang-lsp] to version 0.2.0
 
 ## v2.0.1
 
- * Update [yang-sprotty](https://github.com/TypeFox/yang-sprotty) to version 0.2.2
+* Update [yang-sprotty][yang-sprotty] to version 0.2.2
 
 ## v2.0.0
 
- * Added [yang-sprotty](https://github.com/TypeFox/yang-sprotty) diagrams provided through [sprotty-vscode](https://github.com/eclipse/sprotty-vscode)
- * Switched to released version 0.1.0 of [yang-lsp](https://github.com/TypeFox/yang-lsp), replacing the previously used snapshots from the build server
+* Added [yang-sprotty][yang-sprotty] diagrams provided through [sprotty-vscode][sprotty-vscode]
+* Switched to released version 0.1.0 of [yang-lsp][yang-lsp], replacing the
+  previously used snapshots from the build server
+
+[yang-lsp]: https://github.com/TypeFox/yang-lsp
+[sprotty-vscode]: https://github.com/eclipse/sprotty-vscode
+[yang-sprotty]: https://github.com/TypeFox/yang-sprotty

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-Language support for YANG for Visual Studio Code
-=====================
+YANG Language support for Visual Studio Code
+============================================
 
-Provides [YANG](https://tools.ietf.org/html/rfc7950) language support via
-[YANG Language Server](https://github.com/TypeFox/yang-lsp).
+Provides [YANG][yang1.1] language support via [YANG Language Server][yang-lsp].
 
 Quick Start
-============
+-----------
+
 1. Install the Extension
 2. If you do not have a _Java 11_ correctly installed
     * Download and install a Java 11 runtime environment.
@@ -13,11 +13,12 @@ Quick Start
 4. Use "Open in Diagram" from the context menu to see the graphical model view.
 
 Features
-=========
+--------
+
 ![ templates ](https://raw.githubusercontent.com/TypeFox/yang-vscode/master/images/yang-templates.gif)
 ![ completion ](https://raw.githubusercontent.com/TypeFox/yang-vscode/master/images/yang-completion.gif)
 ![ navigation ](https://raw.githubusercontent.com/TypeFox/yang-vscode/master/images/yang-navigation.gif)
-<img src="https://raw.githubusercontent.com/TypeFox/yang-vscode/master/images/yang-diagram.png" width="480"/>
+<img src="https://raw.githubusercontent.com/TypeFox/yang-vscode/master/images/yang-diagram.png" width="480" alt=""/><!-- markdownlint-disable-line MD033 -->
 
 * As you type reporting of parsing and compilation errors
 * Code completion
@@ -33,5 +34,10 @@ Features
 * Diagrams
 
 Configuration
-=============
-For configuration and further services, please have a look at the [docs of the YANG Language Server](https://github.com/TypeFox/yang-lsp/tree/master/docs).
+-------------
+
+For configuration and further services, please have a look at the [docs of the YANG Language Server][yang-lsp-docs].
+
+[yang1.1]: https://tools.ietf.org/html/rfc7950
+[yang-lsp]: https://github.com/TypeFox/yang-lsp
+[yang-lsp-docs]: https://github.com/TypeFox/yang-lsp/tree/master/docs


### PR DESCRIPTION
Added github workflow to check markdown for issues.

Also added .editorconfig corresponding to current coding style.

This addresses TypeFox/yang-vscode#88