### PR TITLE
Allow empty line comments in syntax highlighting

### DIFF
--- a/syntaxes/yang.tmLanguage.json
+++ b/syntaxes/yang.tmLanguage.json
@@ -23,7 +23,7 @@
 		},
 		{
 			"name": "comment.line.yang",
-			"match": "//.+"
+			"match": "//.*"
 		},
 		{
 			"name": "comment.block.yang",


### PR DESCRIPTION
The existing regex required at least one character in to match a comment, but it is also possibly to have a comment with no contents, and this should still be highlighted correctly.

Before:

![Screenshot 2024-06-07 at 14 17 56](https://github.com/TypeFox/yang-vscode/assets/11131775/7c1fd85e-fe44-4619-a719-fad1836e84d6)

After:

![Screenshot 2024-06-07 at 14 18 01](https://github.com/TypeFox/yang-vscode/assets/11131775/9191a92b-8648-4d64-be92-fa1691d07c49)
